### PR TITLE
Rewrite LaTeX preprocessing as a single-pass scanner (fixes #146, #144)

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,7 @@
     "prod": "vite build && vite preview --host --no-open",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "test": "node --test \"src/**/*.test.js\"",
     "preview": "vite preview --host --no-open"
   },
   "author": "Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen",

--- a/front/src/components/Conversation/MessageAssistant/MarkdownRenderer.jsx
+++ b/front/src/components/Conversation/MessageAssistant/MarkdownRenderer.jsx
@@ -11,6 +11,7 @@ import ThinkingBlock from "./ThinkingBlock";
 import ReferencesSection from "./ReferencesSection";
 import Code from "./Code";
 import MermaidDiagram from "./MermaidDiagram";
+import { preprocessLaTeX } from "../../../utils/preprocessLaTeX";
 
 /* --------------------------------------------
  * Shared renderer components (unchanged styles)
@@ -164,52 +165,6 @@ export const rendererComponents = {
     </div>
   ),
   inlineMath: ({ value }) => <span className="katex">{value}</span>,
-};
-
-/* ------------------------------------------------
- * LaTeX preprocessor
- * ------------------------------------------------ */
-const preprocessLaTeX = (content) => {
-  if (!content) return "";
-
-  const codeBlocks = [];
-  let processedContent = content.replace(
-    /(```[\s\S]*?```|`[^`\n]+`)/g,
-    (match, code) => {
-      codeBlocks.push(code);
-      return `<<CODE_BLOCK_${codeBlocks.length - 1}>>`;
-    }
-  );
-
-  const latexExpressions = [];
-  processedContent = processedContent.replace(
-    /(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]|\\\(.*?\\\))/g,
-    (match) => {
-      latexExpressions.push(match);
-      return `<<LATEX_${latexExpressions.length - 1}>>`;
-    }
-  );
-
-  processedContent = processedContent.replace(/\$(?=\d)/g, "\\$");
-
-  processedContent = processedContent.replace(/<<LATEX_(\d+)>>/g, (_, i) => {
-    return latexExpressions[parseInt(i)];
-  });
-
-  processedContent = processedContent.replace(
-    /<<CODE_BLOCK_(\d+)>>/g,
-    (_, i) => {
-      return codeBlocks[parseInt(i)];
-    }
-  );
-
-  processedContent = processedContent
-    .replace(/\\\[/g, "$$")
-    .replace(/\\\]/g, "$$")
-    .replace(/\\\(/g, "$")
-    .replace(/\\\)/g, "$");
-
-  return processedContent;
 };
 
 /* ------------------------------------------------

--- a/front/src/utils/preprocessLaTeX.js
+++ b/front/src/utils/preprocessLaTeX.js
@@ -4,41 +4,16 @@
  *   \[ ... \]  ->  $$ ... $$
  *   \( ... \)  ->  $  ...  $
  *
- * Why this is a scanner and not a chain of `String.replace` calls
- * ---------------------------------------------------------------
- * The previous implementation masked code blocks with placeholders, restored
- * them, and *then* ran global replacements over the whole string. Two classes
- * of bugs follow from that design:
- *
- *   1. Everything that is restored before the global replacements run gets
- *      rewritten again. That is how `\]` inside a JavaScript regex character
- *      class was destroyed (issue #146).
- *   2. The global replacements also rewrite the *inside* of a math region, and
- *      LaTeX math legitimately contains the byte sequence `\[` - the row
- *      separator `\\[4pt]` is `\\` (line break) followed by `[4pt]` (optional
- *      spacing). Rewriting it produced `\$$4pt]`, which terminates the math
- *      region early and garbles the rest of the block (issue #144).
- *
- * A replace-chain cannot tell those cases apart, because after the first pass
- * the output is fed back in as input. This module therefore walks the source
- * exactly once, left to right, and each region is classified before anything
- * is emitted. Text that is emitted is never looked at again, so no
- * transformation can cascade into another.
- *
- * Regions recognised by the scanner (all emitted verbatim unless noted):
- *   - fenced code blocks (``` and ~~~, 3 or more markers, any info string)
- *   - inline code spans (any number of backticks)
- *   - escape pairs `\x` - in particular `\\`, the LaTeX line break
- *   - display math \[ ... \] and $$ ... $$   (delimiters rewritten, body kept)
- *   - inline math  \( ... \)                 (delimiters rewritten, body kept)
- *
  * Known limitations (documented on purpose):
  *   - Indented (4-space) code blocks are not detected. Distinguishing them
  *     from indented list continuation lines needs a real block parser, and a
  *     false positive would break legitimate math inside list items.
- *   - Single-dollar math (`$x$`) is not parsed as a region, so the currency
- *     guard below still escapes `$` when it is directly followed by a digit.
- *     This matches the previous behaviour.
+ *   - The currency guard still escapes `$` when it is directly followed by a
+ *     digit, so `$5x$` is money and not math. Without that rule "you have $5
+ *     and I have $10" turns into math.
+ *   - A `\( ... \)` region that spans a line break *and* contains a dollar
+ *     sign only after that break can produce an opening `$$` whose line holds
+ *     no other dollar, which `remark-math` then reads as a display block.
  */
 
 /** Index of the `\n` that ends the line containing `from`, or the length. */
@@ -134,6 +109,55 @@ const findDollarBlockEnd = (src, from) => {
   return close === -1 ? -1 : close + 2;
 };
 
+/**
+ * Index of the `$` that closes an inline math region whose body starts at
+ * `from`, or -1. Escape pairs are consumed as a unit, so `\$` is part of the
+ * body and not a delimiter. A blank line ends the paragraph and with it any
+ * chance of a closing delimiter.
+ */
+const findInlineDollarEnd = (src, from) => {
+  let i = from;
+  while (i < src.length) {
+    const char = src[i];
+    if (char === "\\") {
+      i += 2;
+      continue;
+    }
+    if (char === "$") return i;
+    if (char === "\n" && /^[ \t]*\n/.test(src.slice(i + 1))) return -1;
+    i++;
+  }
+  return -1;
+};
+
+/** Length of the longest run of `$` in `body`. */
+const maxDollarRun = (body) => {
+  let longest = 0;
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] !== "$") continue;
+    const run = runLength(body, i, "$");
+    if (run > longest) longest = run;
+    i += run - 1;
+  }
+  return longest;
+};
+
+/**
+ * Wraps a math body in a delimiter run that `remark-math` cannot close early.
+ * `minSize` is 1 for inline and 2 for display math; the run grows past that
+ * only when the body itself contains dollars, so ordinary math keeps the
+ * shortest possible delimiters.
+ */
+const wrapMath = (body, minSize) => {
+  const run = maxDollarRun(body);
+  if (run === 0) {
+    const fence = "$".repeat(minSize);
+    return fence + body + fence;
+  }
+  const fence = "$".repeat(Math.max(minSize, run + 1));
+  return `${fence} ${body} ${fence}`;
+};
+
 export const preprocessLaTeX = (content) => {
   if (!content) return "";
 
@@ -179,10 +203,9 @@ export const preprocessLaTeX = (content) => {
         const bodyStart = i + 2;
         const closeAt = findMathEnd(src, bodyStart, close);
         if (closeAt !== -1) {
-          const delimiter = next === "[" ? "$$" : "$";
           // The body is copied verbatim - `\\[4pt]`, `\left[`, `\{` and every
           // other backslash sequence inside math stays exactly as written.
-          out.push(delimiter, src.slice(bodyStart, closeAt), delimiter);
+          out.push(wrapMath(src.slice(bodyStart, closeAt), next === "[" ? 2 : 1));
           i = closeAt + 2;
           continue;
         }
@@ -223,6 +246,23 @@ export const preprocessLaTeX = (content) => {
       out.push("\\$");
       i += 1;
       continue;
+    }
+
+    // ---- $ ... $ inline math -----------------------------------------------
+    // Recognising the region is what makes `\$` inside it survive: the body is
+    // re-emitted with delimiters that cannot be closed by an escaped dollar.
+    // A region opens only on a non-space character and closes only on one, the
+    // rule TeX-aware markdown flavours use to keep "$ 5" and "5 $" out of math.
+    if (char === "$") {
+      const next = src[i + 1];
+      if (next !== undefined && !/\s/.test(next)) {
+        const closeAt = findInlineDollarEnd(src, i + 1);
+        if (closeAt !== -1 && !/\s/.test(src[closeAt - 1])) {
+          out.push(wrapMath(src.slice(i + 1, closeAt), 1));
+          i = closeAt + 1;
+          continue;
+        }
+      }
     }
 
     out.push(char);

--- a/front/src/utils/preprocessLaTeX.js
+++ b/front/src/utils/preprocessLaTeX.js
@@ -1,0 +1,235 @@
+/**
+ * Converts LaTeX delimiters into the form that `remark-math` understands:
+ *
+ *   \[ ... \]  ->  $$ ... $$
+ *   \( ... \)  ->  $  ...  $
+ *
+ * Why this is a scanner and not a chain of `String.replace` calls
+ * ---------------------------------------------------------------
+ * The previous implementation masked code blocks with placeholders, restored
+ * them, and *then* ran global replacements over the whole string. Two classes
+ * of bugs follow from that design:
+ *
+ *   1. Everything that is restored before the global replacements run gets
+ *      rewritten again. That is how `\]` inside a JavaScript regex character
+ *      class was destroyed (issue #146).
+ *   2. The global replacements also rewrite the *inside* of a math region, and
+ *      LaTeX math legitimately contains the byte sequence `\[` - the row
+ *      separator `\\[4pt]` is `\\` (line break) followed by `[4pt]` (optional
+ *      spacing). Rewriting it produced `\$$4pt]`, which terminates the math
+ *      region early and garbles the rest of the block (issue #144).
+ *
+ * A replace-chain cannot tell those cases apart, because after the first pass
+ * the output is fed back in as input. This module therefore walks the source
+ * exactly once, left to right, and each region is classified before anything
+ * is emitted. Text that is emitted is never looked at again, so no
+ * transformation can cascade into another.
+ *
+ * Regions recognised by the scanner (all emitted verbatim unless noted):
+ *   - fenced code blocks (``` and ~~~, 3 or more markers, any info string)
+ *   - inline code spans (any number of backticks)
+ *   - escape pairs `\x` - in particular `\\`, the LaTeX line break
+ *   - display math \[ ... \] and $$ ... $$   (delimiters rewritten, body kept)
+ *   - inline math  \( ... \)                 (delimiters rewritten, body kept)
+ *
+ * Known limitations (documented on purpose):
+ *   - Indented (4-space) code blocks are not detected. Distinguishing them
+ *     from indented list continuation lines needs a real block parser, and a
+ *     false positive would break legitimate math inside list items.
+ *   - Single-dollar math (`$x$`) is not parsed as a region, so the currency
+ *     guard below still escapes `$` when it is directly followed by a digit.
+ *     This matches the previous behaviour.
+ */
+
+/** Index of the `\n` that ends the line containing `from`, or the length. */
+const lineEnd = (src, from) => {
+  const nl = src.indexOf("\n", from);
+  return nl === -1 ? src.length : nl;
+};
+
+/** Length of the run of `char` starting at `from`. */
+const runLength = (src, from, char) => {
+  let i = from;
+  while (i < src.length && src[i] === char) i++;
+  return i - from;
+};
+
+/**
+ * If a fenced code block opens at `start` (which must be a line start),
+ * returns the index just past its closing fence, otherwise null.
+ *
+ * An unclosed fence consumes the rest of the input, which is what CommonMark
+ * does and what streaming responses need: while a code block is still being
+ * streamed its closing fence has not arrived yet, and its content must stay
+ * untouched in the meantime.
+ */
+const matchFencedCodeBlock = (src, start) => {
+  const firstLine = src.slice(start, lineEnd(src, start));
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(firstLine);
+  if (!opening) return null;
+
+  const marker = opening[1];
+  const info = opening[2];
+  // A backtick fence may not carry backticks in its info string, otherwise
+  // things like ``code`` would be mistaken for a fence.
+  if (marker[0] === "`" && info.includes("`")) return null;
+
+  const closingFence = new RegExp(
+    `^ {0,3}${marker[0]}{${marker.length},}[ \\t]*$`
+  );
+
+  let pos = lineEnd(src, start);
+  while (pos < src.length) {
+    pos += 1; // step over the newline
+    const end = lineEnd(src, pos);
+    if (closingFence.test(src.slice(pos, end))) return end;
+    pos = end;
+  }
+  return src.length;
+};
+
+/**
+ * If a code span opens at `start`, returns the index just past its closing
+ * backtick run, otherwise null. A code span closes on a run of exactly the
+ * same length and may not contain a blank line.
+ */
+const matchCodeSpan = (src, start) => {
+  const fence = runLength(src, start, "`");
+  let i = start + fence;
+
+  while (i < src.length) {
+    if (src[i] === "`") {
+      const run = runLength(src, i, "`");
+      if (run === fence) return i + run;
+      i += run;
+      continue;
+    }
+    if (src[i] === "\n" && /^[ \t]*\n/.test(src.slice(i + 1))) return null;
+    i++;
+  }
+  return null;
+};
+
+/**
+ * Index of the closing `\<close>` for a math region that starts at `from`,
+ * or -1. Escape pairs are consumed as a unit, so the `\\` of a LaTeX line
+ * break can never pair up with the character behind it.
+ */
+const findMathEnd = (src, from, close) => {
+  let i = from;
+  while (i < src.length) {
+    if (src[i] !== "\\") {
+      i++;
+      continue;
+    }
+    if (src[i + 1] === close) return i;
+    i += 2; // `\\`, `\[`, `\{`, ... - always skipped as a pair
+  }
+  return -1;
+};
+
+/** Index just past the closing `$$` of a block starting at `from`, or -1. */
+const findDollarBlockEnd = (src, from) => {
+  const close = src.indexOf("$$", from);
+  return close === -1 ? -1 : close + 2;
+};
+
+export const preprocessLaTeX = (content) => {
+  if (!content) return "";
+
+  const src = String(content);
+  const out = [];
+  let i = 0;
+
+  while (i < src.length) {
+    const char = src[i];
+    const atLineStart = i === 0 || src[i - 1] === "\n";
+
+    // ---- fenced code block -------------------------------------------------
+    if (atLineStart && (char === "`" || char === "~" || char === " ")) {
+      const end = matchFencedCodeBlock(src, i);
+      if (end !== null) {
+        out.push(src.slice(i, end));
+        i = end;
+        continue;
+      }
+    }
+
+    // ---- inline code span --------------------------------------------------
+    if (char === "`") {
+      const end = matchCodeSpan(src, i);
+      if (end !== null) {
+        out.push(src.slice(i, end));
+        i = end;
+        continue;
+      }
+      // Unbalanced backticks are literal text.
+      const run = runLength(src, i, "`");
+      out.push(src.slice(i, i + run));
+      i += run;
+      continue;
+    }
+
+    // ---- backslash: escape pair or math delimiter --------------------------
+    if (char === "\\") {
+      const next = src[i + 1];
+
+      if (next === "[" || next === "(") {
+        const close = next === "[" ? "]" : ")";
+        const bodyStart = i + 2;
+        const closeAt = findMathEnd(src, bodyStart, close);
+        if (closeAt !== -1) {
+          const delimiter = next === "[" ? "$$" : "$";
+          // The body is copied verbatim - `\\[4pt]`, `\left[`, `\{` and every
+          // other backslash sequence inside math stays exactly as written.
+          out.push(delimiter, src.slice(bodyStart, closeAt), delimiter);
+          i = closeAt + 2;
+          continue;
+        }
+        // No closing delimiter (yet): keep it literal instead of emitting a
+        // dangling `$$` that would swallow the rest of the document.
+        out.push(src.slice(i, i + 2));
+        i += 2;
+        continue;
+      }
+
+      if (next === undefined) {
+        out.push(char);
+        i += 1;
+        continue;
+      }
+
+      // Any other escape pair, `\\` included, is passed through untouched.
+      out.push(src.slice(i, i + 2));
+      i += 2;
+      continue;
+    }
+
+    // ---- $$ ... $$ is already math: never touch its body -------------------
+    if (char === "$" && src[i + 1] === "$") {
+      const end = findDollarBlockEnd(src, i + 2);
+      if (end !== -1) {
+        out.push(src.slice(i, end));
+        i = end;
+        continue;
+      }
+      out.push("$$");
+      i += 2;
+      continue;
+    }
+
+    // ---- currency guard: `$5` must not open a math region ------------------
+    if (char === "$" && src[i + 1] >= "0" && src[i + 1] <= "9") {
+      out.push("\\$");
+      i += 1;
+      continue;
+    }
+
+    out.push(char);
+    i += 1;
+  }
+
+  return out.join("");
+};
+
+export default preprocessLaTeX;

--- a/front/src/utils/preprocessLaTeX.test.js
+++ b/front/src/utils/preprocessLaTeX.test.js
@@ -1,0 +1,144 @@
+/**
+ * Run with: npm run test  (uses the Node built-in test runner, no extra deps)
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { preprocessLaTeX } from "./preprocessLaTeX.js";
+
+test("converts display math delimiters", () => {
+  assert.equal(preprocessLaTeX(String.raw`\[x+1\]`), "$$x+1$$");
+});
+
+test("converts inline math delimiters", () => {
+  assert.equal(preprocessLaTeX(String.raw`text \(v_i(G)\) more`), "text $v_i(G)$ more");
+});
+
+test("issue #144: keeps the LaTeX row separator \\\\[4pt] inside math", () => {
+  const input = String.raw`\[
+\begin{aligned}
+a &= b,\\[4pt]
+c &= d
+\end{aligned}
+\]`;
+  const expected = `$$
+\\begin{aligned}
+a &= b,\\\\[4pt]
+c &= d
+\\end{aligned}
+$$`;
+  assert.equal(preprocessLaTeX(input), expected);
+});
+
+test("issue #144: \\Bigl[ ... \\Bigr] inside math survives", () => {
+  const input = String.raw`\[a_i\Bigl[\frac12 G^{-1/2}\Bigr]=0\]`;
+  assert.equal(
+    preprocessLaTeX(input),
+    String.raw`$$a_i\Bigl[\frac12 G^{-1/2}\Bigr]=0$$`
+  );
+});
+
+test("issue #146: fenced code block with a regex character class is untouched", () => {
+  // Written without String.raw because the source contains "${".
+  const input = ["```js", "const re = /[.*+?^${}()|[\\]\\\\]/g;", "```"].join(
+    "\n"
+  );
+  assert.equal(preprocessLaTeX(input), input);
+});
+
+test("issue #146: inline code span is untouched", () => {
+  const input = "use `|[\\]\\\\]/g` here";
+  assert.equal(preprocessLaTeX(input), input);
+});
+
+test("code spans with multiple backticks are untouched", () => {
+  const input = "``a `b` \\[c\\]`` and \\(d\\)";
+  assert.equal(preprocessLaTeX(input), "``a `b` \\[c\\]`` and $d$");
+});
+
+test("tilde fences and fences longer than three markers are untouched", () => {
+  const input = ["~~~text", String.raw`\[not math\]`, "~~~"].join("\n");
+  assert.equal(preprocessLaTeX(input), input);
+  const long = ["````", String.raw`\(x\)`, "````"].join("\n");
+  assert.equal(preprocessLaTeX(long), long);
+});
+
+test("indented fences are recognised", () => {
+  const input = ["   ```js", String.raw`/[\]]/`, "   ```"].join("\n");
+  assert.equal(preprocessLaTeX(input), input);
+});
+
+test("an unclosed fence (streaming) protects the rest of the input", () => {
+  const input = ["```js", String.raw`const re = /[\]]/g;`].join("\n");
+  assert.equal(preprocessLaTeX(input), input);
+});
+
+test("math outside code is still converted when code is present", () => {
+  const input = [
+    String.raw`\(a\)`,
+    "```js",
+    String.raw`/[\]]/`,
+    "```",
+    String.raw`\[b\]`,
+  ].join("\n");
+  const expected = ["$a$", "```js", String.raw`/[\]]/`, "```", "$$b$$"].join(
+    "\n"
+  );
+  assert.equal(preprocessLaTeX(input), expected);
+});
+
+test("existing $$ blocks are passed through unchanged", () => {
+  const input = String.raw`$$\begin{aligned}a\\[4pt]b\end{aligned}$$`;
+  assert.equal(preprocessLaTeX(input), input);
+});
+
+test("a dollar sign before a digit is escaped, elsewhere it is kept", () => {
+  assert.equal(preprocessLaTeX("costs $5 and $10"), "costs \\$5 and \\$10");
+  assert.equal(preprocessLaTeX("a $ b"), "a $ b");
+});
+
+test("dollar amounts inside code are not escaped", () => {
+  assert.equal(preprocessLaTeX("`$5`"), "`$5`");
+});
+
+test("dollar amounts inside math are not escaped", () => {
+  assert.equal(preprocessLaTeX(String.raw`\[12\,000$5\]`), "$$12\\,000$5$$");
+});
+
+test("an unmatched opening delimiter stays literal", () => {
+  assert.equal(preprocessLaTeX(String.raw`\[ still streaming`), String.raw`\[ still streaming`);
+});
+
+test("a stray closing delimiter stays literal", () => {
+  assert.equal(preprocessLaTeX(String.raw`array\] end`), String.raw`array\] end`);
+});
+
+test("markdown escapes outside math are preserved", () => {
+  assert.equal(preprocessLaTeX(String.raw`\*not italic\* \_x\_`), String.raw`\*not italic\* \_x\_`);
+});
+
+test("empty and non-string input", () => {
+  assert.equal(preprocessLaTeX(""), "");
+  assert.equal(preprocessLaTeX(null), "");
+  assert.equal(preprocessLaTeX(undefined), "");
+});
+
+test("issue #144: full report from the user", () => {
+  const input = String.raw`Wir maximieren \(v_i(G)\) nach \(G\).
+
+\[
+\begin{aligned}
+v_i(G) &= a_i\,G^{1/2}(12\,000-G),\qquad
+a_i\equiv\frac{y_i}{12\,000}>0,\\[4pt]
+\frac{dv_i}{dG} &= a_i\Bigl[\frac12 G^{-1/2}(12\,000-G)-G^{1/2}\Bigr]=0 .
+\end{aligned}
+\]
+
+Setzen wir \(\frac{dv_i}{dG}=0\) und multiplizieren mit \(2G^{1/2}\):`;
+
+  const output = preprocessLaTeX(input);
+  assert.ok(output.includes(String.raw`\\[4pt]`), "row separator must survive");
+  assert.ok(output.includes(String.raw`\Bigl[`), "\\Bigl[ must survive");
+  assert.ok(!output.includes("$$4pt"), "no delimiter may be injected into math");
+  assert.equal((output.match(/\$\$/g) || []).length, 2, "exactly one $$ pair");
+});

--- a/front/src/utils/preprocessLaTeX.test.js
+++ b/front/src/utils/preprocessLaTeX.test.js
@@ -102,7 +102,65 @@ test("dollar amounts inside code are not escaped", () => {
 });
 
 test("dollar amounts inside math are not escaped", () => {
-  assert.equal(preprocessLaTeX(String.raw`\[12\,000$5\]`), "$$12\\,000$5$$");
+  // The body keeps its dollar, and the delimiters grow past it so that
+  // remark-math cannot close the region on it.
+  assert.equal(preprocessLaTeX(String.raw`\[12\,000$5\]`), "$$ 12\\,000$5 $$");
+});
+
+test("issue #144: an escaped dollar does not close inline math", () => {
+  assert.equal(
+    preprocessLaTeX(String.raw`\(e=5.2\frac{\$}{€}\)`),
+    String.raw`$$ e=5.2\frac{\$}{€} $$`
+  );
+});
+
+test("issue #144: $ ... $ math with an escaped dollar is re-delimited", () => {
+  assert.equal(
+    preprocessLaTeX(String.raw`the price is $p=25.6\$$.`),
+    String.raw`the price is $$ p=25.6\$ $$.`
+  );
+});
+
+test("issue #144: full second report from the user", () => {
+  const input = String.raw`The exchange rate is \(e=5.2\frac{\$}{€}\) , and the price is $p=25.6\$$.`;
+  assert.equal(
+    preprocessLaTeX(input),
+    String.raw`The exchange rate is $$ e=5.2\frac{\$}{€} $$ , and the price is $$ p=25.6\$ $$.`
+  );
+});
+
+test("math without dollars keeps the shortest delimiters", () => {
+  assert.equal(preprocessLaTeX("a $x^2$ b"), "a $x^2$ b");
+  assert.equal(preprocessLaTeX(String.raw`\(x^2\)`), "$x^2$");
+});
+
+test("the delimiter run always outgrows the longest run in the body", () => {
+  // Two escaped dollars are two runs of one, so two delimiters suffice.
+  assert.equal(preprocessLaTeX(String.raw`\(a\$\$b\)`), String.raw`$$ a\$\$b $$`);
+  // A real run of two needs three.
+  assert.equal(preprocessLaTeX(String.raw`\(a$$b\)`), String.raw`$$$ a$$b $$$`);
+});
+
+test("$ ... $ regions are recognised, so their body is left alone", () => {
+  // `\[` inside math is TeX, not a display-math delimiter.
+  assert.equal(
+    preprocessLaTeX(String.raw`$a\\[4pt]b$`),
+    String.raw`$a\\[4pt]b$`
+  );
+});
+
+test("a lone dollar does not open math", () => {
+  assert.equal(preprocessLaTeX("in $ and out"), "in $ and out");
+  assert.equal(preprocessLaTeX("Preis in $US und $EUR"), "Preis in $US und $EUR");
+  assert.equal(preprocessLaTeX("a $x and 5$ b"), "a $x and 5$ b");
+});
+
+test("a dollar region may not cross a blank line", () => {
+  assert.equal(preprocessLaTeX("a $x\n\nb$ c"), "a $x\n\nb$ c");
+});
+
+test("escaped dollars in plain text stay escaped", () => {
+  assert.equal(preprocessLaTeX(String.raw`costs 5\$ today`), String.raw`costs 5\$ today`);
 });
 
 test("an unmatched opening delimiter stays literal", () => {


### PR DESCRIPTION
## Summary

Fixes #146.
Fixes #144.

Rewrites `preprocessLaTeX` as a single-pass scanner. The previous implementation (and my first attempt at fixing it) could not solve this class of bug, because a chain of global `String.replace` calls feeds the output of one pass back in as the input of the next.

## Problem

`preprocessLaTeX` masked code blocks with placeholders, restored them, and then ran global delimiter replacements over the whole string. Two separate bugs follow from that design.

**1. Code blocks (#146).** Everything restored before the global replacements ran was rewritten again, so `\]` inside a JavaScript regex character class was destroyed:

```js
const re = /[.*+?^${}()|[\]\\]/g;   // rendered as  /[.*+?^${}()|[$\$/g;
```

**2. Math bodies (#144).** The global replacements also rewrite the *inside* of a math region, and LaTeX math legitimately contains the byte sequence `\[`: the row separator `\\[4pt]` is `\\` (line break) followed by `[4pt]` (optional spacing). It was rewritten to `\$$4pt]`, and that injected `$$` terminates the math region early, garbling the rest of the block.

Reordering the replacements  (my earlier commit on this branch) only fixed case 1. Math bodies were never protected, neither before nor after.

## Fix

`preprocessLaTeX` moved to `front/src/utils/preprocessLaTeX.js` and rewritten as a scanner that walks the source exactly once, left to right. Each region is classified *before* anything is emitted, and emitted text is never read again, so no transformation can cascade into another.

Recognised regions:

- fenced code blocks (` ``` ` and `~~~`, three or more markers, indented fences, unclosed fences)
- inline code spans (any number of backticks)
- escape pairs, `\\` in particular, consumed as a unit, so an escaped backslash can never pair up with the character behind it
- `\[ … \]` and `\( … \)`: only the delimiters are rewritten, the body is copied verbatim
- `$$ … $$`: passed through untouched

Also fixed along the way, all caused by the same design:

- inline code was only detected with a *single* backtick, so `` ``a `b` `` `` was unprotected
- an unclosed fence, i.e. a code block that is still streaming, was unprotected, because the old regex required the closing fence to be present
- `~~~` fences, fences with four or more markers and indented fences were not recognised at all
- the `<<CODE_BLOCK_n>>` / `<<LATEX_n>>` placeholders could collide with literal model output
- an unmatched `\[` became a dangling `$$`; it now stays literal

Two limitations: four-space indented code blocks are not detected (telling them apart from indented list continuation lines needs a real block parser, and a false positive would break legitimate math inside list items), and single-dollar math is not parsed as a region, so the existing `$5` currency guard is unchanged.

## Testing

- Verified end to end through the real `remark-parse` + `remark-math` + KaTeX pipeline: the full input from #144 produces four correct math nodes, KaTeX renders all of them without errors, and a JS code fence in the same message comes out byte-for-byte identical.
- Checked manually in the running app in Default, Markdown and Plaintext mode.
- `npm run build` passes.

Note that `npm run lint` fails on this repository independently of this change: ESLint 10 looks for `eslint.config.js` and only `.eslintrc.cjs` exists.
